### PR TITLE
fix: docs/更新をPR経由で行うよう変更（mainブランチ保護に対応）

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   build-and-deploy:
@@ -35,10 +36,13 @@ jobs:
           rm -rf docs
           cp -r build/web docs
 
-      - name: Commit and push updated docs/
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/
-          git diff --cached --quiet || git commit -m "chore: update web build for GitHub Pages"
-          git push origin main
+      - name: Create Pull Request to update docs/
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update web build for GitHub Pages"
+          title: "chore: update web build for GitHub Pages"
+          body: "Flutter webビルドの成果物で `docs/` を自動更新します。"
+          branch: chore/update-web-build
+          base: main
+          delete-branch: true


### PR DESCRIPTION
直接pushの代わりにpeter-evans/create-pull-requestで
自動PRを作成する方式に変更。

https://claude.ai/code/session_013yC8Tki6YVZncv75wm1MN5