### PR TITLE
 5問制とけっか画面を追加

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -9,6 +9,7 @@ import 'package:clock_learning/services/progress_service.dart';
 import 'package:clock_learning/services/audio_service.dart';
 import 'package:clock_learning/services/storage_service.dart';
 import 'package:clock_learning/utils/random_clock_start.dart';
+import 'package:clock_learning/screens/result_screen.dart';
 
 /// ゲーム画面の状態管理
 class GameState extends ChangeNotifier {
@@ -17,6 +18,11 @@ class GameState extends ChangeNotifier {
   final ProblemGeneratorService problemGenerator;
   final ProgressService progressService;
   final AudioService audioService;
+
+  static const int maxQuestions = 5;
+  int _questionCount = 0;
+  int _correctCount = 0;
+  bool _isSessionComplete = false;
 
   Problem? _currentProblem;
   List<Problem> _recentProblems = [];
@@ -34,14 +40,22 @@ class GameState extends ChangeNotifier {
   Problem? get currentProblem => _currentProblem;
   bool get isChecking => _isChecking;
   bool? get lastResult => _lastResult;
+  int get questionCount => _questionCount;
+  int get correctCount => _correctCount;
+  int get incorrectCount => _questionCount - _correctCount;
+  bool get isSessionComplete => _isSessionComplete;
 
   /// ゲームを開始
   void startGame() {
+    _questionCount = 0;
+    _correctCount = 0;
+    _isSessionComplete = false;
     _generateNextProblem();
   }
 
   /// 次の問題を生成
   void _generateNextProblem() {
+    _questionCount++;
     _currentProblem = problemGenerator.generateProblem(
       level,
       recentProblems: _recentProblems,
@@ -78,6 +92,7 @@ class GameState extends ChangeNotifier {
     );
 
     _lastResult = isCorrect;
+    if (isCorrect) _correctCount++;
 
     // 音声フィードバック
     if (isCorrect) {
@@ -96,13 +111,23 @@ class GameState extends ChangeNotifier {
     // 正解のときだけ一定時間後に次の問題へ（不正解のときは「つぎのもんだい」タップで進む）
     if (isCorrect) {
       await Future.delayed(const Duration(milliseconds: 1500));
-      _generateNextProblem();
+      if (_questionCount >= maxQuestions) {
+        _isSessionComplete = true;
+        notifyListeners();
+      } else {
+        _generateNextProblem();
+      }
     }
   }
 
   /// 次の問題へ進む（不正解表示中に「つぎのもんだい」タップで呼ばれる）
   void goToNextProblem() {
-    _generateNextProblem();
+    if (_questionCount >= maxQuestions) {
+      _isSessionComplete = true;
+      notifyListeners();
+    } else {
+      _generateNextProblem();
+    }
   }
 }
 
@@ -171,9 +196,38 @@ class _GameScreenState extends State<GameScreen> {
         ),
         body: Consumer<GameState>(
           builder: (context, gameState, _) {
+            if (gameState.isSessionComplete) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (mounted) {
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => ResultScreen(
+                        correctCount: gameState.correctCount,
+                        incorrectCount: gameState.incorrectCount,
+                        level: widget.level,
+                      ),
+                    ),
+                  );
+                }
+              });
+            }
             return Column(
               children: [
                 const SizedBox(height: 20),
+                // 問題番号
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Text(
+                        '${gameState.questionCount} / ${GameState.maxQuestions} もん',
+                        style: const TextStyle(fontSize: 18, color: Colors.grey),
+                      ),
+                    ],
+                  ),
+                ),
                 // 問題文
                 Column(
                   mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:clock_learning/screens/free_play_screen.dart';
 import 'package:clock_learning/screens/level_select_screen.dart';
 import 'package:clock_learning/screens/progress_screen.dart';
 
@@ -75,6 +76,33 @@ class HomeScreen extends StatelessWidget {
                 ),
                 child: const Text(
                   'すすみぐあいをみる',
+                  style: TextStyle(fontSize: 20),
+                ),
+              ),
+            ),
+            const SizedBox(height: 30),
+            // じゆうにさわるボタン
+            SizedBox(
+              width: 280,
+              height: 80,
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const FreePlayScreen(),
+                    ),
+                  );
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.purple,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                ),
+                child: const Text(
+                  'じゆうにさわる',
                   style: TextStyle(fontSize: 20),
                 ),
               ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:clock_learning/screens/free_play_screen.dart';
 import 'package:clock_learning/screens/level_select_screen.dart';
 import 'package:clock_learning/screens/progress_screen.dart';
 
@@ -76,33 +75,6 @@ class HomeScreen extends StatelessWidget {
                 ),
                 child: const Text(
                   'すすみぐあいをみる',
-                  style: TextStyle(fontSize: 20),
-                ),
-              ),
-            ),
-            const SizedBox(height: 30),
-            // じゆうにさわるボタン
-            SizedBox(
-              width: 280,
-              height: 80,
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => const FreePlayScreen(),
-                    ),
-                  );
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.purple,
-                  foregroundColor: Colors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                ),
-                child: const Text(
-                  'じゆうにさわる',
                   style: TextStyle(fontSize: 20),
                 ),
               ),

--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:clock_learning/models/level.dart';
+import 'package:clock_learning/screens/game_screen.dart';
 
 /// 結果画面（5問終了後）
 class ResultScreen extends StatelessWidget {
@@ -118,8 +119,12 @@ class ResultScreen extends StatelessWidget {
                   height: 64,
                   child: ElevatedButton(
                     onPressed: () {
-                      // Replace ResultScreen with a new GameScreen
-                      Navigator.pop(context);
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => GameScreen(level: level),
+                        ),
+                      );
                     },
                     style: ElevatedButton.styleFrom(
                       backgroundColor: Colors.blue,

--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:clock_learning/models/level.dart';
+
+/// 結果画面（5問終了後）
+class ResultScreen extends StatelessWidget {
+  final int correctCount;
+  final int incorrectCount;
+  final Level level;
+
+  const ResultScreen({
+    super.key,
+    required this.correctCount,
+    required this.incorrectCount,
+    required this.level,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final total = correctCount + incorrectCount;
+    final allCorrect = correctCount == total;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('けっか'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        automaticallyImplyLeading: false,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              allCorrect ? 'ぜんもんせいかい！🎉' : 'おわったよ！',
+              style: const TextStyle(
+                fontSize: 32,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 48),
+            // 正解数
+            Container(
+              width: 280,
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.green.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: Colors.green, width: 2),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.check_circle, color: Colors.green, size: 40),
+                  const SizedBox(width: 12),
+                  Text(
+                    'せいかい $correctCount もん',
+                    style: const TextStyle(
+                      fontSize: 28,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.green,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 20),
+            // 不正解数
+            Container(
+              width: 280,
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.red.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: Colors.red, width: 2),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.cancel, color: Colors.red, size: 40),
+                  const SizedBox(width: 12),
+                  Text(
+                    'まちがい $incorrectCount もん',
+                    style: const TextStyle(
+                      fontSize: 28,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.red,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 48),
+            // もういちど / もどる
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                SizedBox(
+                  width: 130,
+                  height: 64,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      // Pop twice: ResultScreen + GameScreen
+                      Navigator.pop(context);
+                      Navigator.pop(context);
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.grey,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                    ),
+                    child: const Text('もどる', style: TextStyle(fontSize: 18)),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                SizedBox(
+                  width: 130,
+                  height: 64,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      // Replace ResultScreen with a new GameScreen
+                      Navigator.pop(context);
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.blue,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                    ),
+                    child: const Text('もういちど', style: TextStyle(fontSize: 18)),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/clock_painter.dart
+++ b/lib/widgets/clock_painter.dart
@@ -11,6 +11,21 @@ class ClockPainter extends CustomPainter {
   /// 不正解表示時は true で文字盤を緑に描画する
   final bool faceBackgroundGreen;
 
+  static const List<Color> _numberColors = [
+    Colors.red,
+    Colors.orange,
+    Colors.amber,
+    Color(0xFF4CAF50), // green
+    Colors.teal,
+    Colors.blue,
+    Colors.indigo,
+    Colors.purple,
+    Colors.pink,
+    Colors.deepOrange,
+    Color(0xFF00BCD4), // cyan
+    Color(0xFF8BC34A), // light green
+  ];
+
   ClockPainter({
     required this.state,
     required this.clockRadius,
@@ -39,6 +54,9 @@ class ClockPainter extends CustomPainter {
 
     // 分針の描画
     _drawMinuteHand(canvas, center, radius);
+
+    // 中心ドットの描画
+    _drawCenterDot(canvas, center, radius);
   }
 
   /// 1分ごとの目盛り線を描画（むずかしいモードのみ）
@@ -56,12 +74,12 @@ class ClockPainter extends CustomPainter {
         final angle = (i * 6.0 - 90.0) * (pi / 180); // 12時を上にするため-90度
         final startRadius = radius * 0.85; // 目盛り線の開始位置
         final endRadius = radius * 0.92; // 目盛り線の終了位置
-        
+
         final startX = center.dx + cos(angle) * startRadius;
         final startY = center.dy + sin(angle) * startRadius;
         final endX = center.dx + cos(angle) * endRadius;
         final endY = center.dy + sin(angle) * endRadius;
-        
+
         canvas.drawLine(
           Offset(startX, startY),
           Offset(endX, endY),
@@ -74,28 +92,35 @@ class ClockPainter extends CustomPainter {
   /// 時計盤を描画
   void _drawClockFace(Canvas canvas, Offset center, double radius) {
     final paint = Paint()
-      ..color = faceBackgroundGreen ? Colors.green : Colors.white
+      ..color = faceBackgroundGreen ? Colors.green : const Color(0xFFFFF9E6)
       ..style = PaintingStyle.fill;
 
     canvas.drawCircle(center, radius, paint);
 
-    // 時計盤の縁
+    // 時計盤の縁（レベル別カラー）
+    final Color borderColor;
+    switch (level) {
+      case Level.easy:
+        borderColor = Colors.blue;
+        break;
+      case Level.normal:
+        borderColor = Colors.orange;
+        break;
+      case Level.hard:
+        borderColor = Colors.red;
+        break;
+    }
+
     final borderPaint = Paint()
-      ..color = Colors.grey[300]!
+      ..color = borderColor
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 4.0;
+      ..strokeWidth = 6.0;
 
     canvas.drawCircle(center, radius, borderPaint);
   }
 
   /// 数字（1〜12）を描画
   void _drawNumbers(Canvas canvas, Offset center, double radius) {
-    final textStyle = TextStyle(
-      fontSize: radius * 0.15,
-      fontWeight: FontWeight.bold,
-      color: Colors.black87,
-    );
-
     // TextPainterを再利用してメモリ効率を向上
     final textPainter = TextPainter(
       textAlign: TextAlign.center,
@@ -108,6 +133,12 @@ class ClockPainter extends CustomPainter {
       final numberRadius = radius * 0.75; // 数字は時計盤の75%の位置
       final x = center.dx + cos(angle) * numberRadius;
       final y = center.dy + sin(angle) * numberRadius;
+
+      final textStyle = TextStyle(
+        fontSize: radius * 0.15,
+        fontWeight: FontWeight.bold,
+        color: _numberColors[i - 1],
+      );
 
       textPainter.text = TextSpan(
         text: i.toString(),
@@ -124,9 +155,9 @@ class ClockPainter extends CustomPainter {
   /// 時針を描画
   void _drawHourHand(Canvas canvas, Offset center, double radius) {
     final paint = Paint()
-      ..color = Colors.black87
+      ..color = Colors.indigo
       ..style = PaintingStyle.stroke
-      ..strokeWidth = radius * 0.03 // 時針の太さ
+      ..strokeWidth = radius * 0.05 // 時針の太さ
       ..strokeCap = StrokeCap.round;
 
     final handLength = radius * 0.5; // 時針の長さ
@@ -142,16 +173,12 @@ class ClockPainter extends CustomPainter {
   void _drawMinuteHand(Canvas canvas, Offset center, double radius) {
     // ドラッグ中は色と太さを変更（色覚多様性対応：色＋太さ変更の併用）
     final isDragging = state.interactionState == ClockInteractionState.dragging;
-    final color = isDragging ? Colors.blue : Colors.black87;
-    // ドラッグ中は太さを1.5倍にして視覚的フィードバックを強化
-    final strokeWidth = isDragging 
-        ? radius * 0.03  // ドラッグ中は太く
-        : radius * 0.02; // 通常時
+    final color = isDragging ? Colors.blue : Colors.red;
 
     final paint = Paint()
       ..color = color
       ..style = PaintingStyle.stroke
-      ..strokeWidth = strokeWidth
+      ..strokeWidth = radius * 0.03
       ..strokeCap = StrokeCap.round;
 
     final handLength = radius * 0.7; // 分針の長さ
@@ -161,6 +188,15 @@ class ClockPainter extends CustomPainter {
     final endY = center.dy + sin(angle) * handLength;
 
     canvas.drawLine(center, Offset(endX, endY), paint);
+  }
+
+  /// 中心ドットを描画
+  void _drawCenterDot(Canvas canvas, Offset center, double radius) {
+    final paint = Paint()
+      ..color = Colors.black87
+      ..style = PaintingStyle.fill;
+
+    canvas.drawCircle(center, radius * 0.04, paint);
   }
 
   @override


### PR DESCRIPTION
## 変更内容

ゲームを5問1セットにして、終了後にけっか画面を表示するようにしました。

### 機能
- 5問ごとにセッション終了
- けっか画面で正解数・スコアを表示
- 「もういちど」「もどる」ボタンで再プレイ or ホームへ
- 時計デザインもカラフルに更新

## 変更ファイル
- `lib/screens/game_screen.dart`
- `lib/screens/result_screen.dart`（新規）
- `lib/screens/home_screen.dart`
- `lib/widgets/clock_painter.dart`

Closes #8
