### PR TITLE
feat: じゆうにさわるモードを追加 (#4)

### DIFF
--- a/lib/screens/free_play_screen.dart
+++ b/lib/screens/free_play_screen.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:clock_learning/widgets/clock_widget.dart';
+import 'package:clock_learning/widgets/clock_controller.dart';
+import 'package:clock_learning/models/level.dart';
+
+/// じゆうにさわる画面
+class FreePlayScreen extends StatefulWidget {
+  const FreePlayScreen({super.key});
+
+  @override
+  State<FreePlayScreen> createState() => _FreePlayScreenState();
+}
+
+class _FreePlayScreenState extends State<FreePlayScreen> {
+  final ClockController _controller = ClockController();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.initialize(12, 0, Level.hard);
+    _controller.addListener(_onClockChanged);
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onClockChanged);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onClockChanged() {
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hour = _controller.getCurrentHour();
+    final minute = _controller.getCurrentMinute();
+    final timeText = '$hour時${minute == 0 ? 'ちょうど' : '$minute分'}';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('じゆうにさわる'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Text(
+            'じっくりさわってみよう！',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 40),
+          Center(
+            child: ClockWidget(
+              controller: _controller,
+              level: Level.hard,
+              size: 300,
+            ),
+          ),
+          const SizedBox(height: 40),
+          Text(
+            timeText,
+            style: const TextStyle(
+              fontSize: 36,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'はりをうごかしてみてね',
+            style: TextStyle(fontSize: 18, color: Colors.grey),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/free_play_screen.dart
+++ b/lib/screens/free_play_screen.dart
@@ -18,26 +18,16 @@ class _FreePlayScreenState extends State<FreePlayScreen> {
   void initState() {
     super.initState();
     _controller.initialize(12, 0, Level.hard);
-    _controller.addListener(_onClockChanged);
   }
 
   @override
   void dispose() {
-    _controller.removeListener(_onClockChanged);
     _controller.dispose();
     super.dispose();
   }
 
-  void _onClockChanged() {
-    setState(() {});
-  }
-
   @override
   Widget build(BuildContext context) {
-    final hour = _controller.getCurrentHour();
-    final minute = _controller.getCurrentMinute();
-    final timeText = '$hour時${minute == 0 ? 'ちょうど' : '$minute分'}';
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('じゆうにさわる'),
@@ -59,12 +49,20 @@ class _FreePlayScreenState extends State<FreePlayScreen> {
             ),
           ),
           const SizedBox(height: 40),
-          Text(
-            timeText,
-            style: const TextStyle(
-              fontSize: 36,
-              fontWeight: FontWeight.bold,
-            ),
+          ListenableBuilder(
+            listenable: _controller,
+            builder: (context, _) {
+              final hour = _controller.getCurrentHour();
+              final minute = _controller.getCurrentMinute();
+              final timeText = '$hour時${minute == 0 ? 'ちょうど' : '$minute分'}';
+              return Text(
+                timeText,
+                style: const TextStyle(
+                  fontSize: 36,
+                  fontWeight: FontWeight.bold,
+                ),
+              );
+            },
           ),
           const SizedBox(height: 16),
           const Text(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:clock_learning/screens/level_select_screen.dart';
 import 'package:clock_learning/screens/progress_screen.dart';
+import 'package:clock_learning/screens/free_play_screen.dart';
 
 /// アプリのホーム画面
 class HomeScreen extends StatelessWidget {
@@ -75,6 +76,33 @@ class HomeScreen extends StatelessWidget {
                 ),
                 child: const Text(
                   'すすみぐあいをみる',
+                  style: TextStyle(fontSize: 20),
+                ),
+              ),
+            ),
+            const SizedBox(height: 30),
+            // じゆうにさわるボタン
+            SizedBox(
+              width: 280,
+              height: 80,
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const FreePlayScreen(),
+                    ),
+                  );
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.purple,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                ),
+                child: const Text(
+                  'じゆうにさわる',
                   style: TextStyle(fontSize: 20),
                 ),
               ),


### PR DESCRIPTION
https://claude.ai/code/session_013yC8Tki6YVZncv75wm1MN5

## 変更内容

採点なしで時計を自由に動かして遊べる「じゆうにさわるモード」を追加しました。

### 機能
- 時計の針をドラッグで自由に操作できる
- 正解・不正解の判定なし・プレッシャーなしで時計に慣れ親しめる
- ホーム画面に「じゆうにさわる」ボタンを追加

## 変更ファイル
- `lib/screens/free_play_screen.dart`（新規）
- `lib/screens/home_screen.dart`

Closes #4
