### PR TITLE
fix: ランダム開始時刻が正解と一致しないよう再生成ループを追加 (#10)

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -51,9 +51,13 @@ class GameState extends ChangeNotifier {
       _recentProblems = _recentProblems.take(10).toList();
     }
 
-    // 時計を初期化（レベルに応じたランダムな開始時刻）
-    final (:hour, :minute) = getRandomClockStart(level);
-    clockController.initialize(hour, minute, level);
+    // 時計を初期化（レベルに応じたランダムな開始時刻、正解と一致しないよう再生成）
+    ({int hour, int minute}) start;
+    do {
+      start = getRandomClockStart(level);
+    } while (start.hour == _currentProblem!.targetTime.hour &&
+             start.minute == _currentProblem!.targetTime.minute);
+    clockController.initialize(start.hour, start.minute, level);
 
     _isChecking = false;
     _lastResult = null;


### PR DESCRIPTION
https://claude.ai/code/session_013yC8Tki6YVZncv75wm1MN5

## 変更内容

ゲーム開始時のランダム時刻が、正解の時刻と同じになってしまう問題を修正しました。

### 原因
`game_screen.dart` でランダムな「スタート時刻」を生成する際に、正解の時刻と一致するケースがあった。

### 修正
正解と一致した場合は再生成するループを追加し、必ずスタート時刻 ≠ 正解時刻になるよう保証。

## 変更ファイル
- `lib/screens/game_screen.dart`

Closes #10
