### PR TITLE
fix/feat: issues #23〜#26 を一括対応

### DIFF
--- a/lib/screens/clock_reading_screen.dart
+++ b/lib/screens/clock_reading_screen.dart
@@ -30,6 +30,8 @@ class _ClockReadingScreenState extends State<ClockReadingScreen> {
 
   int _targetHour = 0;
   int _targetMinute = 0;
+  int _prevTargetHour = -1;
+  int _prevTargetMinute = -1;
   int _questionCount = 0;
   int _correctCount = 0;
 
@@ -59,12 +61,26 @@ class _ClockReadingScreenState extends State<ClockReadingScreen> {
 
   void _nextQuestion() {
     final r = Random();
-    _targetHour = r.nextInt(12) + 1;
-    _targetMinute = switch (widget.level) {
-      Level.easy => 0,
-      Level.normal => (r.nextInt(12)) * 5,
-      Level.hard => r.nextInt(60),
-    };
+    int newHour;
+    int newMinute;
+    int attempts = 0;
+    do {
+      newHour = r.nextInt(12) + 1;
+      newMinute = switch (widget.level) {
+        Level.easy => 0,
+        Level.normal => (r.nextInt(12)) * 5,
+        Level.hard => r.nextInt(60),
+      };
+      attempts++;
+    } while (
+      newHour == _prevTargetHour &&
+      newMinute == _prevTargetMinute &&
+      attempts < 20
+    );
+    _prevTargetHour = _targetHour;
+    _prevTargetMinute = _targetMinute;
+    _targetHour = newHour;
+    _targetMinute = newMinute;
     _clockController.initialize(_targetHour, _targetMinute, widget.level);
     setState(() {
       _hourInput = '';

--- a/lib/screens/free_play_screen.dart
+++ b/lib/screens/free_play_screen.dart
@@ -1,7 +1,25 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:clock_learning/widgets/clock_widget.dart';
 import 'package:clock_learning/widgets/clock_controller.dart';
 import 'package:clock_learning/models/level.dart';
+import 'package:clock_learning/services/audio_service.dart';
+
+/// 時刻ごとに登場する動物の定義
+const _hourAnimals = {
+  1: ('🐱', 'ねこ', 'にゃー！'),
+  2: ('🐶', 'いぬ', 'わんわん！'),
+  3: ('🐰', 'うさぎ', 'ぴょん！'),
+  4: ('🐻', 'くま', 'ぐるる！'),
+  5: ('🐸', 'かえる', 'けろけろ！'),
+  6: ('🐮', 'うし', 'もーもー！'),
+  7: ('🐷', 'ぶた', 'ぶーぶー！'),
+  8: ('🦊', 'きつね', 'こんこん！'),
+  9: ('🐼', 'パンダ', 'もぐもぐ！'),
+  10: ('🦁', 'らいおん', 'がおー！'),
+  11: ('🐯', 'とら', 'がおがお！'),
+  12: ('🦄', 'ユニコーン', 'きらきら～！'),
+};
 
 /// じゆうにさわる画面
 class FreePlayScreen extends StatefulWidget {
@@ -11,19 +29,76 @@ class FreePlayScreen extends StatefulWidget {
   State<FreePlayScreen> createState() => _FreePlayScreenState();
 }
 
-class _FreePlayScreenState extends State<FreePlayScreen> {
+class _FreePlayScreenState extends State<FreePlayScreen>
+    with TickerProviderStateMixin {
   final ClockController _controller = ClockController();
+  AudioService? _audioService;
+
+  int _lastPopupHour = -1;
+  bool _showingPopup = false;
+
+  late AnimationController _popupAnim;
+  late Animation<double> _scaleAnim;
+  Timer? _dismissTimer;
 
   @override
   void initState() {
     super.initState();
     _controller.initialize(12, 0, Level.hard);
+    _controller.addListener(_onTimeChanged);
+
+    _popupAnim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 400),
+    );
+    _scaleAnim = CurvedAnimation(parent: _popupAnim, curve: Curves.elasticOut);
+
+    _initAudio();
+  }
+
+  Future<void> _initAudio() async {
+    final svc = await AudioService.create();
+    if (mounted) _audioService = svc;
   }
 
   @override
   void dispose() {
+    _controller.removeListener(_onTimeChanged);
     _controller.dispose();
+    _popupAnim.dispose();
+    _dismissTimer?.cancel();
+    _audioService?.dispose();
     super.dispose();
+  }
+
+  void _onTimeChanged() {
+    final hour = _controller.getCurrentHour();
+    final minute = _controller.getCurrentMinute();
+
+    if (minute == 0 && hour != _lastPopupHour) {
+      _lastPopupHour = hour;
+      _triggerAnimalPopup(hour);
+    }
+  }
+
+  void _triggerAnimalPopup(int hour) {
+    if (_showingPopup) {
+      _dismissTimer?.cancel();
+      _popupAnim.forward(from: 0.0);
+    } else {
+      setState(() => _showingPopup = true);
+      _popupAnim.forward(from: 0.0);
+    }
+    _audioService?.playCorrectSound();
+
+    _dismissTimer?.cancel();
+    _dismissTimer = Timer(const Duration(seconds: 3), () {
+      if (mounted) {
+        _popupAnim.reverse().then((_) {
+          if (mounted) setState(() => _showingPopup = false);
+        });
+      }
+    });
   }
 
   @override
@@ -33,43 +108,121 @@ class _FreePlayScreenState extends State<FreePlayScreen> {
         title: const Text('じゆうにさわる'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+      body: Stack(
         children: [
-          const Text(
-            'じっくりさわってみよう！',
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text(
+                'じっくりさわってみよう！',
+                style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 40),
+              Center(
+                child: ClockWidget(
+                  controller: _controller,
+                  level: Level.hard,
+                  size: 300,
+                ),
+              ),
+              const SizedBox(height: 40),
+              ListenableBuilder(
+                listenable: _controller,
+                builder: (context, _) {
+                  final hour = _controller.getCurrentHour();
+                  final minute = _controller.getCurrentMinute();
+                  final timeText =
+                      '$hour時${minute == 0 ? 'ちょうど' : '$minute分'}';
+                  return Text(
+                    timeText,
+                    style: const TextStyle(
+                      fontSize: 36,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  );
+                },
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                'はりをうごかしてみてね',
+                style: TextStyle(fontSize: 18, color: Colors.grey),
+              ),
+              const SizedBox(height: 12),
+              const Text(
+                'ちょうどのじかんにどうぶつがでてくるよ！',
+                style: TextStyle(fontSize: 14, color: Colors.grey),
+              ),
+            ],
           ),
-          const SizedBox(height: 40),
-          Center(
-            child: ClockWidget(
-              controller: _controller,
-              level: Level.hard,
-              size: 300,
+          if (_showingPopup && _hourAnimals.containsKey(_lastPopupHour))
+            _AnimalPopup(
+              emoji: _hourAnimals[_lastPopupHour]!.$1,
+              name: _hourAnimals[_lastPopupHour]!.$2,
+              cry: _hourAnimals[_lastPopupHour]!.$3,
+              scaleAnim: _scaleAnim,
             ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AnimalPopup extends StatelessWidget {
+  final String emoji;
+  final String name;
+  final String cry;
+  final Animation<double> scaleAnim;
+
+  const _AnimalPopup({
+    required this.emoji,
+    required this.name,
+    required this.cry,
+    required this.scaleAnim,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ScaleTransition(
+        scale: scaleAnim,
+        child: Container(
+          width: 220,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 28),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(28),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.18),
+                blurRadius: 24,
+                offset: const Offset(0, 8),
+              ),
+            ],
           ),
-          const SizedBox(height: 40),
-          ListenableBuilder(
-            listenable: _controller,
-            builder: (context, _) {
-              final hour = _controller.getCurrentHour();
-              final minute = _controller.getCurrentMinute();
-              final timeText = '$hour時${minute == 0 ? 'ちょうど' : '$minute分'}';
-              return Text(
-                timeText,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(emoji, style: const TextStyle(fontSize: 64)),
+              const SizedBox(height: 8),
+              Text(
+                name,
                 style: const TextStyle(
-                  fontSize: 36,
+                  fontSize: 24,
                   fontWeight: FontWeight.bold,
                 ),
-              );
-            },
+              ),
+              const SizedBox(height: 4),
+              Text(
+                cry,
+                style: const TextStyle(
+                  fontSize: 20,
+                  color: Colors.deepOrange,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
           ),
-          const SizedBox(height: 16),
-          const Text(
-            'はりをうごかしてみてね',
-            style: TextStyle(fontSize: 18, color: Colors.grey),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -135,7 +135,7 @@ class _HomeScreenState extends State<HomeScreen> {
                           icon: Icons.search,
                           label: 'とけいをよむ',
                           sublabel: 'とけいをみてじかんをこたえる',
-                          color: const Color(0xFF00897B),
+                          color: const Color(0xFF1565C0),
                           onTap: () => Navigator.push(
                             context,
                             MaterialPageRoute(
@@ -150,7 +150,7 @@ class _HomeScreenState extends State<HomeScreen> {
                           icon: Icons.touch_app,
                           label: 'とけいをあわせる',
                           sublabel: 'はりをうごかしてじかんをあわせる',
-                          color: const Color(0xFF1E88E5),
+                          color: const Color(0xFF0277BD),
                           onTap: () => Navigator.push(
                             context,
                             MaterialPageRoute(
@@ -165,7 +165,7 @@ class _HomeScreenState extends State<HomeScreen> {
                           icon: Icons.play_circle_outline,
                           label: 'じゆうにさわる',
                           sublabel: 'じゆうにとけいをうごかしてみよう',
-                          color: const Color(0xFF7B1FA2),
+                          color: const Color(0xFF00695C),
                           onTap: () => Navigator.push(
                             context,
                             MaterialPageRoute(
@@ -178,7 +178,7 @@ class _HomeScreenState extends State<HomeScreen> {
                           icon: Icons.bar_chart,
                           label: 'すすみぐあいをみる',
                           sublabel: 'がくしゅうのきろくをかくにん',
-                          color: const Color(0xFF2E7D32),
+                          color: const Color(0xFF283593),
                           onTap: () => Navigator.push(
                             context,
                             MaterialPageRoute(


### PR DESCRIPTION
$(cat <<'EOF'
## 概要

GitHub Issues #23〜#26 を一括で対応したPRです。

## 変更内容

### #23 有料機能を追加 ✅ (前回PR #27 で実装済み → クローズ)
- かんたんモードは無料、ふつう・むずかしいはプレミアム限定
- App Store / Google Play 対応のサブスクリプション（月額・年額）
- Restore Purchases ボタン・プライバシーポリシーリンク等の審査要件対応

### #24 トップ画面のメニューの色合いを統一
- 4つのメニューボタンのカラーをブルー系パレットに統一
  - とけいをよむ: `#1565C0`（ダークブルー）
  - とけいをあわせる: `#0277BD`（ライトブルー）
  - じゆうにさわる: `#00695C`（ティール）
  - すすみぐあいをみる: `#283593`（インディゴ）

### #25 じゆうにさわる — 動物ポップアップ機能を追加
- 1〜12時ちょうどに動物キャラクターが出現
- 12種類の動物（🐱🐶🐰🐻🐸🐮🐷🦊🐼🦁🐯🦄）
- elasticOut アニメーションで登場、3秒後に自動消去
- 登場時に正解音を再生

### #26 連続重複問題バグを修正
- よみとりモードで直前と同じ時刻が出ないよう再抽選ロジックを追加

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `lib/screens/home_screen.dart` | メニューカラー統一 |
| `lib/screens/free_play_screen.dart` | 動物ポップアップ機能追加 |
| `lib/screens/clock_reading_screen.dart` | 重複問題バグ修正 |

## テスト計画

- [ ] ホーム画面のメニューボタンが統一カラーで表示される
- [ ] じゆうにさわるで時針を1〜12時ちょうどに合わせると動物ポップアップが出る
- [ ] よみとりモードで同じ問題が連続して出ないことを確認
- [ ] プレミアム機能（レベルロック・ペイウォール）の動作確認
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABvwD1zmDbiYkuW5umaXB2)_